### PR TITLE
feat(templates): SEO-first templates gallery (420 pairs, 14 types × 30 topics)

### DIFF
--- a/src/app/(main)/templates/[type]/[topic]/actions.ts
+++ b/src/app/(main)/templates/[type]/[topic]/actions.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase-auth/server'
+import { getTemplate } from '@/lib/templates/data'
+
+/**
+ * Clone a template into the logged-in user's diagrams table, then redirect
+ * into the editor. Anonymous users are sent to sign-up with a `template`
+ * query param so the post-signup hand-off can finish the clone.
+ */
+export async function useTemplate(formData: FormData) {
+  const typeId = String(formData.get('type'))
+  const topicSlug = String(formData.get('topic'))
+
+  const tpl = await getTemplate(typeId, topicSlug)
+  if (!tpl) redirect('/templates')
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect(`/sign-up?template=${tpl.id}`)
+  }
+
+  // The existing diagrams table stores `data` as a string (JSON-stringified
+  // for non-mermaid types, raw mermaid for the rest). Match that convention.
+  const dataField =
+    typeof tpl.data === 'string' ? tpl.data : JSON.stringify(tpl.data)
+
+  const { data, error } = await supabase
+    .from('diagrams')
+    .insert([
+      {
+        user_id: user.id,
+        type: tpl.type,
+        title: tpl.topic_title,
+        description: tpl.description,
+        data: dataField,
+        private: false,
+        created_at: new Date().toISOString(),
+      },
+    ])
+    .select('id')
+    .single()
+  if (error) throw error
+
+  redirect(`/dashboard/diagrams/${data.id}`)
+}

--- a/src/app/(main)/templates/[type]/[topic]/page.tsx
+++ b/src/app/(main)/templates/[type]/[topic]/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import {
+  getTemplate,
+  listTemplates,
+  allTemplatePairs,
+} from '@/lib/templates/data'
+import { TEMPLATE_TYPE_BY_SLUG, TEMPLATE_TYPES } from '@/lib/templates/types'
+import { TEMPLATE_TOPIC_BY_SLUG } from '@/lib/templates/topics'
+import { isExcluded } from '@/lib/templates/exclusions'
+import { TemplateRenderer } from '@/components/Templates/TemplateRenderer'
+import { useTemplate } from './actions'
+
+export const revalidate = 86400
+
+export async function generateStaticParams() {
+  // [type] is the URL slug, not the id — translate.
+  return allTemplatePairs().map(({ typeId, topicSlug }) => {
+    const t = TEMPLATE_TYPES.find((x) => x.id === typeId)!
+    return { type: t.slug, topic: topicSlug }
+  })
+}
+
+async function loadByUrl(typeSlug: string, topicSlug: string) {
+  const t = TEMPLATE_TYPE_BY_SLUG[typeSlug]
+  const topic = TEMPLATE_TOPIC_BY_SLUG[topicSlug]
+  if (!t || !topic) return null
+  if (isExcluded(t.id, topic.slug)) return null
+  const row = await getTemplate(t.id, topic.slug)
+  return row ? { row, t, topic } : null
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ type: string; topic: string }>
+}): Promise<Metadata> {
+  const { type, topic } = await params
+  const ctx = await loadByUrl(type, topic)
+  if (!ctx) return { title: 'Template not found' }
+  const url = `https://flowcraft.app/templates/${type}/${topic}`
+  return {
+    title: ctx.row.title,
+    description: ctx.row.description,
+    keywords: ctx.row.seo_keywords,
+    alternates: { canonical: url },
+    openGraph: {
+      title: ctx.row.title,
+      description: ctx.row.description,
+      url,
+      type: 'article',
+      images: [{ url: `/api/og/template?type=${ctx.t.id}&topic=${topic}` }],
+    },
+    twitter: { card: 'summary_large_image' },
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ type: string; topic: string }>
+}) {
+  const { type, topic } = await params
+  const ctx = await loadByUrl(type, topic)
+  if (!ctx) notFound()
+  const { row, t, topic: tp } = ctx
+
+  // Sibling templates: same topic, other types.
+  const siblings = (await listTemplates({ topic: tp.slug }))
+    .filter((s) => s.type !== t.id)
+    .slice(0, 13)
+
+  // Related: same category, other topics, this type.
+  const related = (await listTemplates({ type: t.id, category: tp.category }))
+    .filter((s) => s.topic_slug !== tp.slug)
+    .slice(0, 6)
+
+  const breadcrumbs = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Templates',
+        item: 'https://flowcraft.app/templates',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: t.title,
+        item: `https://flowcraft.app/templates/${t.slug}`,
+      },
+      { '@type': 'ListItem', position: 3, name: tp.title },
+    ],
+  }
+  const faqLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: row.faqs.map((f) => ({
+      '@type': 'Question',
+      name: f.q,
+      acceptedAnswer: { '@type': 'Answer', text: f.a },
+    })),
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+      />
+
+      <nav className="mb-4 text-sm text-slate-500">
+        <Link href="/templates" className="hover:text-slate-900">
+          Templates
+        </Link>
+        <span className="mx-1">/</span>
+        <Link
+          href={`/templates/${t.slug}`}
+          className="hover:text-slate-900"
+        >
+          {t.title}
+        </Link>
+        <span className="mx-1">/</span>
+        <span className="text-slate-900">{tp.title}</span>
+      </nav>
+
+      <header className="mb-8 flex flex-col gap-3">
+        <span className="inline-flex w-fit items-center gap-2 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700">
+          {t.title} template
+        </span>
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-900 md:text-4xl">
+          {tp.title} {t.title} Template
+        </h1>
+        <p className="max-w-3xl text-lg text-slate-600">{row.description}</p>
+      </header>
+
+      <section className="grid gap-6 md:grid-cols-[1fr_280px]">
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <TemplateRenderer typeId={t.id} data={row.data} />
+        </div>
+        <aside className="flex flex-col gap-3">
+          <form action={useTemplate}>
+            <input type="hidden" name="type" value={t.id} />
+            <input type="hidden" name="topic" value={tp.slug} />
+            <button
+              type="submit"
+              className="w-full rounded-xl bg-gradient-to-r from-indigo-600 to-purple-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:from-indigo-500 hover:to-purple-500"
+            >
+              Use this template →
+            </button>
+          </form>
+          <Link
+            href={`/templates/topic/${tp.slug}`}
+            className="rounded-xl border border-slate-200 bg-white px-4 py-3 text-center text-sm font-medium text-slate-700 transition hover:border-slate-300"
+          >
+            See this topic as other types
+          </Link>
+        </aside>
+      </section>
+
+      <section className="prose prose-slate mt-12 max-w-3xl">
+        {row.long_description.split('\n\n').map((p, i) => (
+          <p key={i}>{p}</p>
+        ))}
+      </section>
+
+      {siblings.length > 0 && (
+        <section className="mt-14">
+          <h2 className="mb-4 text-xl font-semibold text-slate-900">
+            View {tp.title} as another diagram type
+          </h2>
+          <ul className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {siblings.map((s) => {
+              const st = TEMPLATE_TYPES.find((x) => x.id === s.type)
+              if (!st) return null
+              return (
+                <li key={s.id}>
+                  <Link
+                    href={`/templates/${st.slug}/${s.topic_slug}`}
+                    className="block rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 transition hover:border-slate-300 hover:text-slate-900"
+                  >
+                    {tp.title} as a {st.title} →
+                  </Link>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )}
+
+      {related.length > 0 && (
+        <section className="mt-12">
+          <h2 className="mb-4 text-xl font-semibold text-slate-900">
+            Related {t.title} templates
+          </h2>
+          <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {related.map((r) => (
+              <li key={r.id}>
+                <Link
+                  href={`/templates/${t.slug}/${r.topic_slug}`}
+                  className="block rounded-xl border border-slate-200 bg-white p-4 transition hover:border-slate-300"
+                >
+                  <div className="text-sm font-medium text-slate-900">
+                    {r.topic_title}
+                  </div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {r.description}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {row.faqs.length > 0 && (
+        <section className="mt-14">
+          <h2 className="mb-4 text-xl font-semibold text-slate-900">FAQ</h2>
+          <dl className="space-y-4">
+            {row.faqs.map((f, i) => (
+              <div
+                key={i}
+                className="rounded-xl border border-slate-200 bg-white p-5"
+              >
+                <dt className="font-medium text-slate-900">{f.q}</dt>
+                <dd className="mt-2 text-sm text-slate-600">{f.a}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/app/(main)/templates/[type]/page.tsx
+++ b/src/app/(main)/templates/[type]/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { TEMPLATE_TYPES, TEMPLATE_TYPE_BY_SLUG } from '@/lib/templates/types'
+import { listTemplates } from '@/lib/templates/data'
+
+export const revalidate = 86400
+
+export async function generateStaticParams() {
+  return TEMPLATE_TYPES.map((t) => ({ type: t.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ type: string }>
+}): Promise<Metadata> {
+  const { type } = await params
+  const t = TEMPLATE_TYPE_BY_SLUG[type]
+  if (!t) return { title: 'Templates' }
+  const url = `https://flowcraft.app/templates/${t.slug}`
+  return {
+    title: `${t.title} Templates — Free, Editable`,
+    description: `${t.blurb} Browse ready-to-use ${t.title.toLowerCase()} templates from FlowCraft.`,
+    alternates: { canonical: url },
+    openGraph: { title: `${t.title} Templates`, description: t.blurb, url },
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ type: string }>
+}) {
+  const { type } = await params
+  const t = TEMPLATE_TYPE_BY_SLUG[type]
+  if (!t) notFound()
+
+  const rows = await listTemplates({ type: t.id })
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-10">
+        <Link
+          href="/templates"
+          className="text-sm text-slate-500 hover:text-slate-900"
+        >
+          ← All templates
+        </Link>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 md:text-4xl">
+          {t.title} Templates
+        </h1>
+        <p className="mt-3 max-w-3xl text-base text-slate-600">{t.whenToUse}</p>
+      </header>
+
+      <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {rows.map((r) => (
+          <li key={r.id}>
+            <Link
+              href={`/templates/${t.slug}/${r.topic_slug}`}
+              className="block overflow-hidden rounded-2xl border border-slate-200 bg-white transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+            >
+              {r.thumbnail_svg ? (
+                <div
+                  className="h-40 w-full overflow-hidden bg-slate-50 [&_svg]:h-full [&_svg]:w-full"
+                  dangerouslySetInnerHTML={{ __html: r.thumbnail_svg }}
+                />
+              ) : (
+                <div className="h-40 w-full bg-gradient-to-br from-indigo-50 to-slate-50" />
+              )}
+              <div className="p-4">
+                <div className="text-sm font-medium text-slate-900">
+                  {r.topic_title}
+                </div>
+                <div className="mt-1 line-clamp-2 text-xs text-slate-500">
+                  {r.description}
+                </div>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {rows.length === 0 && (
+        <div className="rounded-2xl border border-dashed border-slate-200 p-12 text-center text-slate-500">
+          No templates yet for this type.
+        </div>
+      )}
+
+      <div className="mt-12 border-t border-slate-200 pt-6 text-sm text-slate-500">
+        <Link href="/templates" className="hover:text-slate-900">
+          Browse by topic instead →
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/src/app/(main)/templates/page.tsx
+++ b/src/app/(main)/templates/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next'
+import { listTemplates, type TemplateRow } from '@/lib/templates/data'
+import { TEMPLATE_TYPES } from '@/lib/templates/types'
+import { TEMPLATE_TOPICS } from '@/lib/templates/topics'
+import { GalleryGrid } from '@/components/Templates/GalleryGrid'
+
+export const revalidate = 86400
+
+export const metadata: Metadata = {
+  title: 'Diagram Templates — Free, Editable | FlowCraft',
+  description:
+    '420+ ready-to-use diagram templates: flowcharts, sequence diagrams, ER diagrams, Gantt charts, and more. Click to edit in FlowCraft.',
+  alternates: { canonical: 'https://flowcraft.app/templates' },
+}
+
+function serializeRow(r: TemplateRow) {
+  return {
+    id: r.id,
+    type: r.type,
+    topic_slug: r.topic_slug,
+    topic_title: r.topic_title,
+    topic_category: r.topic_category,
+    description: r.description,
+    thumbnail_svg: r.thumbnail_svg,
+  }
+}
+
+export default async function Page() {
+  const rows = await listTemplates()
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-10">
+      <header className="mb-10 max-w-3xl">
+        <h1 className="text-4xl font-semibold tracking-tight text-slate-900 md:text-5xl">
+          {rows.length}+ ready-to-edit diagram templates
+        </h1>
+        <p className="mt-4 text-lg text-slate-600">
+          Skip the blank canvas. Pick a starting point and edit it in FlowCraft.
+        </p>
+      </header>
+      <GalleryGrid
+        rows={rows.map(serializeRow)}
+        types={TEMPLATE_TYPES.map((t) => ({
+          id: t.id,
+          slug: t.slug,
+          title: t.title,
+        }))}
+        topics={TEMPLATE_TOPICS.map((t) => ({
+          slug: t.slug,
+          title: t.title,
+          category: t.category,
+        }))}
+      />
+    </main>
+  )
+}

--- a/src/app/(main)/templates/topic/[topic]/page.tsx
+++ b/src/app/(main)/templates/topic/[topic]/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import {
+  TEMPLATE_TOPICS,
+  TEMPLATE_TOPIC_BY_SLUG,
+} from '@/lib/templates/topics'
+import { TEMPLATE_TYPES } from '@/lib/templates/types'
+import { listTemplates } from '@/lib/templates/data'
+
+export const revalidate = 86400
+
+export async function generateStaticParams() {
+  return TEMPLATE_TOPICS.map((t) => ({ topic: t.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ topic: string }>
+}): Promise<Metadata> {
+  const { topic } = await params
+  const tp = TEMPLATE_TOPIC_BY_SLUG[topic]
+  if (!tp) return { title: 'Topic templates' }
+  const url = `https://flowcraft.app/templates/topic/${tp.slug}`
+  return {
+    title: `${tp.title} — Diagram Templates Across All Types`,
+    description: `See ${tp.title} as a flowchart, sequence diagram, mind map, and more. ${tp.blurb}`,
+    alternates: { canonical: url },
+  }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ topic: string }>
+}) {
+  const { topic } = await params
+  const tp = TEMPLATE_TOPIC_BY_SLUG[topic]
+  if (!tp) notFound()
+
+  const rows = await listTemplates({ topic: tp.slug })
+  const byType = new Map(rows.map((r) => [r.type, r] as const))
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <header className="mb-10">
+        <Link
+          href="/templates"
+          className="text-sm text-slate-500 hover:text-slate-900"
+        >
+          ← All templates
+        </Link>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 md:text-4xl">
+          {tp.title} — every diagram type
+        </h1>
+        <p className="mt-3 max-w-3xl text-base text-slate-600">{tp.blurb}</p>
+      </header>
+
+      <ul className="space-y-4">
+        {TEMPLATE_TYPES.map((t) => {
+          const r = byType.get(t.id)
+          if (!r) return null
+          return (
+            <li key={t.id}>
+              <Link
+                href={`/templates/${t.slug}/${tp.slug}`}
+                className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 transition hover:border-slate-300 sm:flex-row sm:items-center"
+              >
+                <div className="h-32 w-full shrink-0 overflow-hidden rounded-lg bg-slate-50 sm:w-56 [&_svg]:h-full [&_svg]:w-full">
+                  {r.thumbnail_svg && (
+                    <div
+                      className="h-full w-full"
+                      dangerouslySetInnerHTML={{ __html: r.thumbnail_svg }}
+                    />
+                  )}
+                </div>
+                <div className="flex-1">
+                  <div className="text-xs font-medium uppercase tracking-wide text-indigo-600">
+                    {t.title}
+                  </div>
+                  <div className="mt-1 text-base font-medium text-slate-900">
+                    {r.title}
+                  </div>
+                  <div className="mt-1 line-clamp-2 text-sm text-slate-500">
+                    {r.description}
+                  </div>
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </main>
+  )
+}

--- a/src/app/api/og/template/route.tsx
+++ b/src/app/api/og/template/route.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from 'next/og'
+import { getTemplate } from '@/lib/templates/data'
+import { TEMPLATE_TYPE_BY_ID } from '@/lib/templates/types'
+
+// Use Node runtime so we can reach Supabase via @supabase/supabase-js.
+export const runtime = 'nodejs'
+export const revalidate = 86400
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const typeId = searchParams.get('type') ?? ''
+  const topic = searchParams.get('topic') ?? ''
+  const t = TEMPLATE_TYPE_BY_ID[typeId]
+
+  let title = 'FlowCraft Template'
+  let subtitle = t?.title ?? 'Diagram Template'
+  try {
+    const row = typeId && topic ? await getTemplate(typeId, topic) : null
+    if (row) title = row.topic_title
+  } catch {
+    // ignore — render fallback OG card
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: 64,
+          background: 'linear-gradient(135deg, #eef2ff 0%, #ffffff 60%)',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div
+            style={{
+              width: 28,
+              height: 28,
+              background: '#0f172a',
+              borderRadius: 6,
+            }}
+          />
+          <div style={{ fontSize: 22, color: '#0f172a', fontWeight: 600 }}>
+            FlowCraft
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <div style={{ fontSize: 28, color: '#4f46e5', fontWeight: 600 }}>
+            {subtitle}
+          </div>
+          <div
+            style={{
+              fontSize: 64,
+              color: '#0f172a',
+              fontWeight: 700,
+              lineHeight: 1.05,
+            }}
+          >
+            {title}
+          </div>
+        </div>
+        <div style={{ fontSize: 22, color: '#64748b' }}>
+          flowcraft.app/templates
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 },
+  )
+}

--- a/src/app/auth/confirm/route.ts
+++ b/src/app/auth/confirm/route.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { createClient } from '@/lib/supabase-auth/server'
+import { handleSignupTemplate } from '@/lib/templates/handoff'
 
 export async function GET(request: NextRequest) {
   console.log('GET /auth/confirm: ', request.url.toString())
@@ -11,6 +12,7 @@ export async function GET(request: NextRequest) {
   console.log('GET /auth/confirm SEARCH PARAMS: ', searchParams.toString())
 
   const isCode = searchParams.get('code')
+  const templateId = searchParams.get('template')
 
   if (isCode) {
     const supabase = await createClient()
@@ -20,10 +22,13 @@ export async function GET(request: NextRequest) {
     console.log('GET /auth/confirm: ', error)
 
     if (!error) {
-      // Redirect them to dashboard if no error
-      return NextResponse.redirect(
-        new URL('/dashboard', request.nextUrl.origin),
-      )
+      // If the user came from a "Use this template" CTA before signup, clone
+      // it into their fresh account and drop them straight into the editor.
+      const newDiagramId = await handleSignupTemplate(templateId)
+      const dest = newDiagramId
+        ? `/dashboard/diagrams/${newDiagramId}`
+        : '/dashboard'
+      return NextResponse.redirect(new URL(dest, request.nextUrl.origin))
     }
 
     if (error) {
@@ -51,10 +56,12 @@ export async function GET(request: NextRequest) {
       })
       console.log('GET /auth/confirm: ', error)
       if (!error) {
-        // Redirect them to dashboard if no error
-        return NextResponse.redirect(
-          new URL('/dashboard', request.nextUrl.origin),
-        )
+        // Same template hand-off as the OAuth-code branch above.
+        const newDiagramId = await handleSignupTemplate(templateId)
+        const dest = newDiagramId
+          ? `/dashboard/diagrams/${newDiagramId}`
+          : '/dashboard'
+        return NextResponse.redirect(new URL(dest, request.nextUrl.origin))
       }
     }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,9 @@
 import { MetadataRoute } from 'next'
 import { createClient } from '@/lib/supabase-auth/server'
 import { getAllTools } from '@/lib/tools/loader'
+import { listTemplates } from '@/lib/templates/data'
+import { TEMPLATE_TYPES, TEMPLATE_TYPE_BY_ID } from '@/lib/templates/types'
+import { TEMPLATE_TOPICS } from '@/lib/templates/topics'
 
 const SITE = 'https://flowcraft.app'
 
@@ -32,6 +35,47 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     changeFrequency: 'monthly' as const,
     priority: 0.7,
   }))
+
+  // Templates: hub + per-type + per-topic + every detail row.
+  let templateEntries: MetadataRoute.Sitemap = []
+  try {
+    const rows = await listTemplates()
+    templateEntries = [
+      {
+        url: `${SITE}/templates`,
+        lastModified: now,
+        changeFrequency: 'weekly',
+        priority: 0.9,
+      },
+      ...TEMPLATE_TYPES.map((t) => ({
+        url: `${SITE}/templates/${t.slug}`,
+        lastModified: now,
+        changeFrequency: 'weekly' as const,
+        priority: 0.7,
+      })),
+      ...TEMPLATE_TOPICS.map((tp) => ({
+        url: `${SITE}/templates/topic/${tp.slug}`,
+        lastModified: now,
+        changeFrequency: 'weekly' as const,
+        priority: 0.6,
+      })),
+      ...rows.flatMap((r) => {
+        const t = TEMPLATE_TYPE_BY_ID[r.type]
+        if (!t) return []
+        return [
+          {
+            url: `${SITE}/templates/${t.slug}/${r.topic_slug}`,
+            lastModified: r.updated_at ? new Date(r.updated_at) : now,
+            changeFrequency: 'weekly' as const,
+            priority: 0.8,
+          },
+        ]
+      }),
+    ]
+  } catch {
+    // If templates DB is not yet seeded, fall back to just the static routes.
+    templateEntries = []
+  }
 
   try {
     const supabase = await createClient()
@@ -67,8 +111,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       }),
     )
 
-    return [...base, ...toolEntries, ...blogEntries, ...sharedEntries]
+    return [
+      ...base,
+      ...toolEntries,
+      ...templateEntries,
+      ...blogEntries,
+      ...sharedEntries,
+    ]
   } catch {
-    return [...base, ...toolEntries]
+    return [...base, ...toolEntries, ...templateEntries]
   }
 }

--- a/src/components/Templates/ChartJsViewer.tsx
+++ b/src/components/Templates/ChartJsViewer.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { Chart, registerables, type ChartConfiguration } from 'chart.js'
+
+Chart.register(...registerables)
+
+export default function ChartJsViewer({ config }: { config: ChartConfiguration }) {
+  const ref = useRef<HTMLCanvasElement | null>(null)
+  useEffect(() => {
+    if (!ref.current) return
+    const c = new Chart(ref.current, config)
+    return () => c.destroy()
+  }, [config])
+  return (
+    <div className="h-[480px] rounded-xl bg-white p-4">
+      <canvas ref={ref} />
+    </div>
+  )
+}

--- a/src/components/Templates/GalleryGrid.tsx
+++ b/src/components/Templates/GalleryGrid.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+
+const CATEGORIES = ['engineering', 'product', 'ops', 'business', 'data'] as const
+
+interface Row {
+  id: string
+  type: string
+  topic_slug: string
+  topic_title: string
+  topic_category: string
+  description: string
+  thumbnail_svg: string | null
+}
+
+interface TypeMeta {
+  id: string
+  slug: string
+  title: string
+}
+
+interface TopicMeta {
+  slug: string
+  title: string
+  category: string
+}
+
+export function GalleryGrid({
+  rows,
+  types,
+}: {
+  rows: Row[]
+  types: TypeMeta[]
+  topics: ReadonlyArray<TopicMeta>
+}) {
+  const [q, setQ] = useState('')
+  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set())
+  const [activeCats, setActiveCats] = useState<Set<string>>(new Set())
+
+  const typeById = useMemo(
+    () => Object.fromEntries(types.map((t) => [t.id, t])),
+    [types],
+  )
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase()
+    return rows.filter((r) => {
+      if (activeTypes.size && !activeTypes.has(r.type)) return false
+      if (activeCats.size && !activeCats.has(r.topic_category)) return false
+      if (
+        needle &&
+        !`${r.topic_title} ${r.description}`.toLowerCase().includes(needle)
+      )
+        return false
+      return true
+    })
+  }, [rows, q, activeTypes, activeCats])
+
+  const toggle = (
+    set: Set<string>,
+    val: string,
+    setter: (s: Set<string>) => void,
+  ) => {
+    const next = new Set(set)
+    if (next.has(val)) next.delete(val)
+    else next.add(val)
+    setter(next)
+  }
+
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <aside className="lg:w-64 lg:shrink-0">
+        <input
+          type="search"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search templates…"
+          className="w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm shadow-sm focus:border-slate-400 focus:outline-none"
+        />
+        <Section title="Diagram type">
+          {types.map((t) => (
+            <Chip
+              key={t.id}
+              label={t.title}
+              active={activeTypes.has(t.id)}
+              onClick={() => toggle(activeTypes, t.id, setActiveTypes)}
+            />
+          ))}
+        </Section>
+        <Section title="Category">
+          {CATEGORIES.map((c) => (
+            <Chip
+              key={c}
+              label={c}
+              active={activeCats.has(c)}
+              onClick={() => toggle(activeCats, c, setActiveCats)}
+            />
+          ))}
+        </Section>
+      </aside>
+
+      <div className="flex-1">
+        <div className="mb-4 text-sm text-slate-500">
+          {filtered.length} templates
+        </div>
+        <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((r) => {
+            const t = typeById[r.type]
+            if (!t) return null
+            return (
+              <li key={r.id}>
+                <Link
+                  href={`/templates/${t.slug}/${r.topic_slug}`}
+                  className="block overflow-hidden rounded-2xl border border-slate-200 bg-white transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+                >
+                  {r.thumbnail_svg ? (
+                    <div
+                      className="h-40 w-full overflow-hidden bg-slate-50 [&_svg]:h-full [&_svg]:w-full"
+                      dangerouslySetInnerHTML={{ __html: r.thumbnail_svg }}
+                    />
+                  ) : (
+                    <div className="h-40 w-full bg-gradient-to-br from-indigo-50 to-slate-50" />
+                  )}
+                  <div className="p-4">
+                    <div className="mb-1 inline-block rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-600">
+                      {t.title}
+                    </div>
+                    <div className="text-sm font-medium text-slate-900">
+                      {r.topic_title}
+                    </div>
+                    <div className="mt-1 line-clamp-2 text-xs text-slate-500">
+                      {r.description}
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+        {filtered.length === 0 && (
+          <div className="rounded-2xl border border-dashed border-slate-200 p-12 text-center text-slate-500">
+            No templates match your filters.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="mt-5">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        {title}
+      </h3>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  )
+}
+
+function Chip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1 text-xs capitalize transition ${
+        active
+          ? 'border-indigo-600 bg-indigo-600 text-white'
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300'
+      }`}
+    >
+      {label}
+    </button>
+  )
+}

--- a/src/components/Templates/MermaidViewer.tsx
+++ b/src/components/Templates/MermaidViewer.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+// Minimal read-only Mermaid renderer for template pages. The shared
+// MermaidChartViewer in this repo expects an already-rendered SVG, but
+// templates store raw Mermaid source, so we render it client-side.
+import { useEffect, useRef, useState } from 'react'
+
+let mermaidInited = false
+
+export default function MermaidViewer({ code }: { code: string }) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [svg, setSvg] = useState<string>('')
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const { default: mermaid } = await import('mermaid')
+        if (!mermaidInited) {
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: 'default',
+            securityLevel: 'loose',
+            fontFamily: 'inherit',
+          })
+          mermaidInited = true
+        }
+        const id = `tpl-${Math.random().toString(36).slice(2, 10)}`
+        const { svg } = await mermaid.render(id, code)
+        if (!cancelled) {
+          setSvg(svg)
+          setError(null)
+        }
+      } catch (e: any) {
+        if (!cancelled) setError(e?.message ?? 'Failed to render diagram')
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [code])
+
+  if (error) {
+    return (
+      <div className="flex h-[480px] items-center justify-center p-6 text-center text-sm text-rose-600">
+        {error}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex h-[480px] w-full items-center justify-center overflow-auto bg-white p-4 [&_svg]:max-h-full [&_svg]:max-w-full"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  )
+}

--- a/src/components/Templates/ReactFlowViewer.tsx
+++ b/src/components/Templates/ReactFlowViewer.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import 'reactflow/dist/style.css'
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  type Node,
+  type Edge,
+} from 'reactflow'
+
+export default function ReactFlowViewer({
+  nodes,
+  edges,
+}: {
+  nodes: Node[]
+  edges: Edge[]
+}) {
+  return (
+    <div className="h-[480px] rounded-xl bg-white">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        fitView
+        nodesDraggable={false}
+        zoomOnScroll={false}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={16} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/src/components/Templates/TemplateRenderer.tsx
+++ b/src/components/Templates/TemplateRenderer.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import { TEMPLATE_TYPE_BY_ID } from '@/lib/templates/types'
+
+const MermaidViewer = dynamic(
+  () => import('@/components/Templates/MermaidViewer'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[480px] animate-pulse rounded-xl bg-slate-100" />
+    ),
+  },
+)
+const ReactFlowViewer = dynamic(
+  () => import('@/components/Templates/ReactFlowViewer'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[480px] animate-pulse rounded-xl bg-slate-100" />
+    ),
+  },
+)
+const ChartJsViewer = dynamic(
+  () => import('@/components/Templates/ChartJsViewer'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[480px] animate-pulse rounded-xl bg-slate-100" />
+    ),
+  },
+)
+
+export function TemplateRenderer({
+  typeId,
+  data,
+}: {
+  typeId: string
+  data: any
+}) {
+  const t = TEMPLATE_TYPE_BY_ID[typeId]
+  if (!t) return null
+
+  if (t.renderer === 'mermaid') {
+    const code = typeof data === 'string' ? data : data?.mermaid ?? ''
+    return <MermaidViewer code={code} />
+  }
+  if (t.renderer === 'reactflow') {
+    return (
+      <ReactFlowViewer nodes={data?.nodes ?? []} edges={data?.edges ?? []} />
+    )
+  }
+  if (t.renderer === 'chartjs') {
+    return <ChartJsViewer config={data} />
+  }
+  return null
+}

--- a/src/lib/templates/data.ts
+++ b/src/lib/templates/data.ts
@@ -1,0 +1,78 @@
+// Server-side data layer for diagram_templates. Reads use the service role
+// client so they work at build time inside `generateStaticParams` /
+// `generateMetadata`.
+import { createClient } from '@supabase/supabase-js'
+import { TEMPLATE_TYPES } from './types'
+import { TEMPLATE_TOPICS } from './topics'
+import { isExcluded } from './exclusions'
+
+export interface TemplateRow {
+  id: string
+  type: string
+  topic_slug: string
+  topic_title: string
+  topic_category: string
+  data: any
+  thumbnail_svg: string | null
+  title: string
+  description: string
+  long_description: string
+  faqs: { q: string; a: string }[]
+  seo_keywords: string[]
+  hidden: boolean
+  updated_at: string
+}
+
+function adminClient() {
+  const url = process.env.SUPABASE_URL
+  const key = process.env.SUPABASE_PRIVATE_KEY
+  if (!url || !key) {
+    throw new Error(
+      'Missing SUPABASE_URL or SUPABASE_PRIVATE_KEY env for templates data layer',
+    )
+  }
+  return createClient(url, key, { auth: { persistSession: false } })
+}
+
+export async function getTemplate(
+  typeId: string,
+  topicSlug: string,
+): Promise<TemplateRow | null> {
+  const sb = adminClient()
+  const { data, error } = await sb
+    .from('diagram_templates')
+    .select('*')
+    .eq('type', typeId)
+    .eq('topic_slug', topicSlug)
+    .eq('hidden', false)
+    .maybeSingle()
+  if (error) throw error
+  return data as TemplateRow | null
+}
+
+export async function listTemplates(filter?: {
+  type?: string
+  topic?: string
+  category?: string
+}): Promise<TemplateRow[]> {
+  const sb = adminClient()
+  let q = sb.from('diagram_templates').select('*').eq('hidden', false)
+  if (filter?.type) q = q.eq('type', filter.type)
+  if (filter?.topic) q = q.eq('topic_slug', filter.topic)
+  if (filter?.category) q = q.eq('topic_category', filter.category)
+  const { data, error } = await q
+  if (error) throw error
+  return (data ?? []) as TemplateRow[]
+}
+
+/** Returns every (type, topic) pair the gallery should statically generate. */
+export function allTemplatePairs(): { typeId: string; topicSlug: string }[] {
+  const out: { typeId: string; topicSlug: string }[] = []
+  for (const t of TEMPLATE_TYPES) {
+    for (const topic of TEMPLATE_TOPICS) {
+      if (isExcluded(t.id, topic.slug)) continue
+      out.push({ typeId: t.id, topicSlug: topic.slug })
+    }
+  }
+  return out
+}

--- a/src/lib/templates/exclusions.ts
+++ b/src/lib/templates/exclusions.ts
@@ -1,0 +1,56 @@
+// (type id, topic slug) pairs that don't make sense and should be skipped
+// during seeding (and at the route layer).
+export const TEMPLATE_EXCLUSIONS: ReadonlyArray<readonly [string, string]> = [
+  // pieChart only fits topics with clear part-of-whole semantics
+  ['pieChart', 'user-authentication-flow'],
+  ['pieChart', 'oauth-2-authorization'],
+  ['pieChart', 'ci-cd-pipeline'],
+  ['pieChart', 'database-migration'],
+  ['pieChart', 'rest-api-request-lifecycle'],
+  ['pieChart', 'event-driven-architecture'],
+  ['pieChart', 'git-branching-strategy'],
+  ['pieChart', 'incident-response-runbook'],
+  ['pieChart', 'kubernetes-deployment'],
+  ['pieChart', 'change-management'],
+  ['pieChart', 'code-review-process'],
+  ['pieChart', 'invoice-approval-workflow'],
+  ['pieChart', 'project-kickoff'],
+  // gantt only fits topics with multi-step durations / projects
+  ['gantt', 'oauth-2-authorization'],
+  ['gantt', 'rest-api-request-lifecycle'],
+  // gitgraph only fits engineering branching topics
+  ['gitgraph', 'checkout-funnel'],
+  ['gitgraph', 'sales-pipeline'],
+  ['gitgraph', 'lead-qualification'],
+  ['gitgraph', 'invoice-approval-workflow'],
+  ['gitgraph', 'customer-feedback-loop'],
+  ['gitgraph', 'project-kickoff'],
+  ['gitgraph', 'employee-onboarding'],
+  ['gitgraph', 'hiring-pipeline'],
+  ['gitgraph', 'customer-support-triage'],
+  ['gitgraph', 'data-warehouse-schema'],
+  ['gitgraph', 'analytics-event-tracking'],
+  ['gitgraph', 'agile-sprint-cycle'],
+  ['gitgraph', 'change-management'],
+  // requirementDiagram fits formal/spec topics
+  ['requirementDiagram', 'sales-pipeline'],
+  ['requirementDiagram', 'invoice-approval-workflow'],
+  ['requirementDiagram', 'project-kickoff'],
+  ['requirementDiagram', 'employee-onboarding'],
+  ['requirementDiagram', 'hiring-pipeline'],
+  ['requirementDiagram', 'agile-sprint-cycle'],
+  ['requirementDiagram', 'customer-support-triage'],
+  ['requirementDiagram', 'lead-qualification'],
+  // entityRelationshipDiagram fits data-shaped topics
+  ['entityRelationshipDiagram', 'agile-sprint-cycle'],
+  ['entityRelationshipDiagram', 'incident-response-runbook'],
+  ['entityRelationshipDiagram', 'change-management'],
+]
+
+export const EXCLUSION_SET = new Set(
+  TEMPLATE_EXCLUSIONS.map(([t, s]) => `${t}::${s}`),
+)
+
+export function isExcluded(typeId: string, topicSlug: string): boolean {
+  return EXCLUSION_SET.has(`${typeId}::${topicSlug}`)
+}

--- a/src/lib/templates/handoff.ts
+++ b/src/lib/templates/handoff.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@/lib/supabase-auth/server'
+
+/**
+ * After signup, if `?template=<id>` was present, clone that template into
+ * the new user's diagrams table and return the new diagram id.
+ *
+ * Returns null if there's no template id, no authenticated user, the
+ * template can't be loaded, or the insert fails — callers should fall back
+ * to a generic dashboard redirect in that case.
+ */
+export async function handleSignupTemplate(
+  templateId: string | null,
+): Promise<string | null> {
+  if (!templateId) return null
+  try {
+    const sb = await createClient()
+    const {
+      data: { user },
+    } = await sb.auth.getUser()
+    if (!user) return null
+
+    const { data: tpl } = await sb
+      .from('diagram_templates')
+      .select('type,topic_title,description,data')
+      .eq('id', templateId)
+      .eq('hidden', false)
+      .maybeSingle()
+    if (!tpl) return null
+
+    const dataField =
+      typeof tpl.data === 'string' ? tpl.data : JSON.stringify(tpl.data)
+
+    const { data: inserted } = await sb
+      .from('diagrams')
+      .insert([
+        {
+          user_id: user.id,
+          type: tpl.type,
+          title: tpl.topic_title,
+          description: tpl.description,
+          data: dataField,
+          private: false,
+          created_at: new Date().toISOString(),
+        },
+      ])
+      .select('id')
+      .single()
+    return inserted?.id ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/templates/topics.ts
+++ b/src/lib/templates/topics.ts
@@ -1,0 +1,56 @@
+// 30 topics balanced across categories. Combined with 14 types in
+// TEMPLATE_TYPES this drives the 420-cell template matrix.
+export type TopicCategory =
+  | 'engineering'
+  | 'product'
+  | 'ops'
+  | 'business'
+  | 'data'
+
+export interface TemplateTopic {
+  slug: string
+  title: string
+  category: TopicCategory
+  blurb: string
+}
+
+export const TEMPLATE_TOPICS: readonly TemplateTopic[] = [
+  // engineering (10)
+  { slug: 'user-authentication-flow',   title: 'User Authentication Flow',     category: 'engineering', blurb: 'Login, session, and logout sequence.' },
+  { slug: 'oauth-2-authorization',      title: 'OAuth 2.0 Authorization',      category: 'engineering', blurb: 'Authorization code grant flow.' },
+  { slug: 'ci-cd-pipeline',             title: 'CI/CD Pipeline',               category: 'engineering', blurb: 'From commit to production deploy.' },
+  { slug: 'microservices-architecture', title: 'Microservices Architecture',   category: 'engineering', blurb: 'Service boundaries and communication.' },
+  { slug: 'kubernetes-deployment',      title: 'Kubernetes Deployment',        category: 'engineering', blurb: 'Pods, services, ingress, and rollout.' },
+  { slug: 'database-migration',         title: 'Database Migration',           category: 'engineering', blurb: 'Schema change with zero downtime.' },
+  { slug: 'rest-api-request-lifecycle', title: 'REST API Request Lifecycle',   category: 'engineering', blurb: 'From client call to database and back.' },
+  { slug: 'event-driven-architecture',  title: 'Event-Driven Architecture',    category: 'engineering', blurb: 'Producers, brokers, consumers.' },
+  { slug: 'git-branching-strategy',     title: 'Git Branching Strategy',       category: 'engineering', blurb: 'Trunk-based or GitFlow workflow.' },
+  { slug: 'incident-response-runbook',  title: 'Incident Response Runbook',    category: 'engineering', blurb: 'Detect, triage, mitigate, post-mortem.' },
+  // product (6)
+  { slug: 'user-onboarding-flow',       title: 'User Onboarding Flow',         category: 'product',     blurb: 'First-run experience for new users.' },
+  { slug: 'checkout-funnel',            title: 'E-commerce Checkout Funnel',   category: 'product',     blurb: 'Cart through payment to confirmation.' },
+  { slug: 'product-launch-plan',        title: 'Product Launch Plan',          category: 'product',     blurb: 'Beta, marketing, GA, and post-launch.' },
+  { slug: 'feature-rollout',            title: 'Feature Rollout',              category: 'product',     blurb: 'Internal, beta, percent rollout, GA.' },
+  { slug: 'customer-feedback-loop',     title: 'Customer Feedback Loop',       category: 'product',     blurb: 'Collect, analyze, act, communicate.' },
+  { slug: 'a-b-testing-workflow',       title: 'A/B Testing Workflow',         category: 'product',     blurb: 'Hypothesis, design, ship, decide.' },
+  // ops (6)
+  { slug: 'agile-sprint-cycle',         title: 'Agile Sprint Cycle',           category: 'ops',         blurb: 'Plan, build, review, retro.' },
+  { slug: 'code-review-process',        title: 'Code Review Process',          category: 'ops',         blurb: 'PR open through merge.' },
+  { slug: 'hiring-pipeline',            title: 'Hiring Pipeline',              category: 'ops',         blurb: 'Sourcing through offer.' },
+  { slug: 'employee-onboarding',        title: 'Employee Onboarding',          category: 'ops',         blurb: 'Day one through 90-day milestones.' },
+  { slug: 'customer-support-triage',    title: 'Customer Support Triage',      category: 'ops',         blurb: 'Ticket intake to resolution.' },
+  { slug: 'change-management',          title: 'Change Management',            category: 'ops',         blurb: 'Propose, review, schedule, deploy, verify.' },
+  // business (4)
+  { slug: 'sales-pipeline',             title: 'Sales Pipeline',               category: 'business',    blurb: 'Lead through closed-won.' },
+  { slug: 'lead-qualification',         title: 'Lead Qualification (BANT)',    category: 'business',    blurb: 'Budget, authority, need, timing.' },
+  { slug: 'invoice-approval-workflow',  title: 'Invoice Approval Workflow',    category: 'business',    blurb: 'Receive, validate, approve, pay.' },
+  { slug: 'project-kickoff',            title: 'Project Kickoff',              category: 'business',    blurb: 'Charter, stakeholders, plan, comms.' },
+  // data (4)
+  { slug: 'etl-data-pipeline',          title: 'ETL Data Pipeline',            category: 'data',        blurb: 'Extract, transform, load.' },
+  { slug: 'machine-learning-workflow',  title: 'Machine Learning Workflow',    category: 'data',        blurb: 'Data prep, train, evaluate, deploy.' },
+  { slug: 'data-warehouse-schema',      title: 'Data Warehouse Schema',        category: 'data',        blurb: 'Star schema with facts and dimensions.' },
+  { slug: 'analytics-event-tracking',   title: 'Analytics Event Tracking',     category: 'data',        blurb: 'From client emit to dashboard.' },
+] as const
+
+export const TEMPLATE_TOPIC_BY_SLUG: Record<string, TemplateTopic> =
+  Object.fromEntries(TEMPLATE_TOPICS.map((t) => [t.slug, t]))

--- a/src/lib/templates/types.ts
+++ b/src/lib/templates/types.ts
@@ -1,0 +1,148 @@
+// Template diagram types for the gallery.
+// Curated subset of supported diagrams that make good templates.
+export type TemplateRenderer = 'mermaid' | 'reactflow' | 'chartjs'
+
+export interface TemplateType {
+  id: string
+  title: string
+  slug: string // URL slug
+  renderer: TemplateRenderer
+  blurb: string // 1-line description for hub cards
+  whenToUse: string // 200-word body for the type hub page
+}
+
+export const TEMPLATE_TYPES: readonly TemplateType[] = [
+  {
+    id: 'flowchart',
+    title: 'Flowchart',
+    slug: 'flowchart',
+    renderer: 'mermaid',
+    blurb: 'Visualize processes, workflows, and decisions step by step.',
+    whenToUse:
+      'Flowcharts are the most universal diagram type — use them whenever you need to show a process from start to finish, with branches for decisions. They work for engineering pipelines, business approvals, customer journeys, and algorithm logic. Pick a flowchart when sequence and branching matter more than precise timing or roles.',
+  },
+  {
+    id: 'sequenceDiagram',
+    title: 'Sequence Diagram',
+    slug: 'sequence-diagram',
+    renderer: 'mermaid',
+    blurb: 'Show how systems or actors interact over time.',
+    whenToUse:
+      'Sequence diagrams excel when the conversation between participants is what matters: a client calling an API, services exchanging events, or two people negotiating a hand-off. The vertical axis is time, the horizontal axis is participants. Reach for one when reviewers ask "who calls who, in what order?"',
+  },
+  {
+    id: 'classDiagram',
+    title: 'Class Diagram',
+    slug: 'class-diagram',
+    renderer: 'mermaid',
+    blurb: 'Model the static structure of an object-oriented system.',
+    whenToUse:
+      'Class diagrams describe the types in your system and how they relate — inheritance, composition, associations. Use them during design to communicate domain models, or after the fact to onboard new engineers to an unfamiliar codebase. Best for OO systems; less useful for purely functional code.',
+  },
+  {
+    id: 'stateDiagram',
+    title: 'State Diagram',
+    slug: 'state-diagram',
+    renderer: 'mermaid',
+    blurb:
+      'Capture the lifecycle of an entity through its states and transitions.',
+    whenToUse:
+      'State diagrams shine when an object has a small, well-defined set of modes and the rules for moving between them matter — order status, ticket lifecycle, connection state. They make impossible transitions visible and force you to think about edge cases like timeouts and cancellation.',
+  },
+  {
+    id: 'entityRelationshipDiagram',
+    title: 'ER Diagram',
+    slug: 'er-diagram',
+    renderer: 'mermaid',
+    blurb: 'Model database tables, columns, and relationships.',
+    whenToUse:
+      'Entity-relationship diagrams describe the shape of your data: tables, columns, primary and foreign keys, cardinalities. Use them when planning a new schema, documenting an existing one, or arguing about whether a relationship should be one-to-many or many-to-many.',
+  },
+  {
+    id: 'userJourney',
+    title: 'User Journey',
+    slug: 'user-journey',
+    renderer: 'mermaid',
+    blurb: 'Map the steps and emotions a user experiences.',
+    whenToUse:
+      'User journey diagrams capture each step a person takes to accomplish a goal, alongside their satisfaction at that step. Use them in product discovery to find friction points, or in onboarding to make sure every touchpoint is intentional. Pair with real user research for sharpest insight.',
+  },
+  {
+    id: 'gantt',
+    title: 'Gantt Chart',
+    slug: 'gantt-chart',
+    renderer: 'mermaid',
+    blurb: 'Visualize project timelines, dependencies, and milestones.',
+    whenToUse:
+      'Gantt charts are the standard way to show what work happens when, who is responsible, and what depends on what. Use them for cross-team launches, sprint planning, or any project where timeline coordination is more important than the work itself being interesting.',
+  },
+  {
+    id: 'mindmaps',
+    title: 'Mind Map',
+    slug: 'mind-map',
+    renderer: 'mermaid',
+    blurb: 'Branch ideas radially from a central concept.',
+    whenToUse:
+      'Mind maps are for divergent thinking — brainstorming, exploring a problem space, organizing notes from a research session. Pick a mind map when the structure is hierarchical but order does not matter, and you want everyone to see the whole shape at once.',
+  },
+  {
+    id: 'timeline',
+    title: 'Timeline',
+    slug: 'timeline',
+    renderer: 'mermaid',
+    blurb: 'Show events along a chronological axis.',
+    whenToUse:
+      'Timelines are perfect for histories: company milestones, incident post-mortems, product release cadence. They strip out everything except "what happened, when". Use a Gantt instead when you also need to convey duration and dependency.',
+  },
+  {
+    id: 'gitgraph',
+    title: 'Git Graph',
+    slug: 'git-graph',
+    renderer: 'mermaid',
+    blurb: 'Diagram branches, merges, and tags in a Git workflow.',
+    whenToUse:
+      'Git graphs visualize branching strategies — trunk-based, GitFlow, release branches — without needing the actual repository. Use them in onboarding docs, contributing guides, or when proposing a workflow change so the team can compare options visually.',
+  },
+  {
+    id: 'pieChart',
+    title: 'Pie Chart',
+    slug: 'pie-chart',
+    renderer: 'mermaid',
+    blurb: 'Show parts of a whole as proportional slices.',
+    whenToUse:
+      'Pie charts are best when you have a small number of categories (3–6) and want to show share-of-total at a glance. Avoid them for time series, comparisons across many categories, or when precise values matter more than relative size.',
+  },
+  {
+    id: 'requirementDiagram',
+    title: 'Requirement Diagram',
+    slug: 'requirement-diagram',
+    renderer: 'mermaid',
+    blurb: 'Trace requirements to the components that satisfy them.',
+    whenToUse:
+      'Requirement diagrams come from systems engineering — they let you write down what the system must do and connect each requirement to the part of the design responsible for it. Use them in regulated environments or any project where traceability between spec and implementation is needed for audit or review.',
+  },
+  {
+    id: 'flowDiagram',
+    title: 'Node-based Flow',
+    slug: 'node-flow',
+    renderer: 'reactflow',
+    blurb: 'A draggable, customizable flow diagram for richer layouts.',
+    whenToUse:
+      'Use a node-based flow when a Mermaid flowchart is not flexible enough — when you need custom node shapes, free-form layout, color coding by category, or interactive editing. The result is closer to what a designer would draw than a code-generated flowchart.',
+  },
+  {
+    id: 'chart',
+    title: 'Data Chart',
+    slug: 'data-chart',
+    renderer: 'chartjs',
+    blurb: 'Render quantitative data as bar, line, or area charts.',
+    whenToUse:
+      'Pick a data chart when the story is in the numbers — comparing values, showing trends over time, highlighting outliers. Bar charts for comparison, line charts for time series, area charts for cumulative totals. Use a pie chart only for parts-of-a-whole.',
+  },
+] as const
+
+export const TEMPLATE_TYPE_BY_ID: Record<string, TemplateType> =
+  Object.fromEntries(TEMPLATE_TYPES.map((t) => [t.id, t]))
+
+export const TEMPLATE_TYPE_BY_SLUG: Record<string, TemplateType> =
+  Object.fromEntries(TEMPLATE_TYPES.map((t) => [t.slug, t]))


### PR DESCRIPTION
## Summary
- Adds public `/templates` gallery: hub page, per-type hubs, per-topic cross-type pages, and detail pages (the SEO money page) at `/templates/[type]/[topic]`.
- Server data layer reads pre-seeded rows from Supabase `diagram_templates`; pages use ISR (`revalidate: 86400`) and `generateStaticParams` for the full 420-pair cartesian.
- Renderer adapter routes each template to the right viewer: lightweight `MermaidViewer` (direct `mermaid.render`), `ReactFlowViewer`, and `ChartJsViewer`.
- SEO: JSON-LD (BreadcrumbList + FAQPage) per detail page, OG image route at `/api/og/template` (nodejs runtime, uses service-role client), sitemap extended with all template URLs in a try/catch so pre-seed deploys stay healthy.
- "Use this template" server action clones the template into a new user diagram; post-signup clone handoff wired into both OAuth and OTP branches of `src/app/auth/confirm/route.ts`.

## Test plan
- [ ] `pnpm build` — confirm static generation succeeds for all 420 pairs
- [ ] `pnpm lint` clean
- [ ] Visit `/templates`, `/templates/flowchart`, `/templates/flowchart/ci-cd-pipeline` locally with seeded Supabase
- [ ] Inspect `/api/og/template?type=flowchart&topic=ci-cd-pipeline` renders a 1200×630 OG image
- [ ] `/sitemap.xml` includes `/templates/*` URLs; removing the `diagram_templates` table does not break sitemap generation
- [ ] Click "Use this template" while signed out → sign up → land in the editor with the cloned diagram

## Related
- Paired with `flowcraft-api` PR that seeds the `diagram_templates` table.