### PR TITLE
feat(ui): render agent validation warnings + retrying indicator

### DIFF
--- a/src/app/dashboard/diagrams/new/page.tsx
+++ b/src/app/dashboard/diagrams/new/page.tsx
@@ -92,6 +92,7 @@ export default function NewDiagramPage() {
   const [mermaidCode, setMermaidCode] = useState('')
   const [imageUrl, setImageUrl] = useState('')
   const [diagramId, setDiagramId] = useState<string | null>(null)
+  const [validationWarnings, setValidationWarnings] = useState<string[]>([])
 
   const [zoomLevel, setZoomLevel] = useState(1)
   const [usageData, setUsageData] = useState<any>(null)
@@ -173,11 +174,13 @@ export default function NewDiagramPage() {
 
   useEffect(() => {
     if (streaming.finalResult) {
-      const { code, title, diagramId: streamDiagramId } = streaming.finalResult
+      const { code, title, diagramId: streamDiagramId, validationWarnings: warnings } =
+        streaming.finalResult
       const sanitized = sanitizeMermaid(code)
       setMermaidCode(sanitized)
       if (title) setGeneratedTitle(title)
       setDiagramId(streamDiagramId)
+      setValidationWarnings(warnings || [])
       setIsGenerated(true)
       setIsLoading(false)
       hideLoading()
@@ -277,6 +280,7 @@ export default function NewDiagramPage() {
     setSvgCode('')
     setMermaidCode('')
     setDiagramId(null)
+    setValidationWarnings([])
     setImageUrl('')
     setZoomLevel(1)
     setPosition({ x: 0, y: 0 })
@@ -381,6 +385,9 @@ export default function NewDiagramPage() {
 
       if (data.title) setGeneratedTitle(data.title)
       setDiagramId(data.diagram_id)
+      setValidationWarnings(
+        Array.isArray(data.validation_warnings) ? data.validation_warnings : [],
+      )
       setIsGenerated(true)
     } catch (e: any) {
       setError(e.message || 'An unexpected error occurred.')
@@ -426,6 +433,23 @@ export default function NewDiagramPage() {
               </p>
             </div>
           </div>
+
+          {validationWarnings.length > 0 && (
+            <div
+              role="status"
+              className="mb-6 rounded-sm border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-amber-200"
+            >
+              <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.22em] text-amber-300">
+                <span aria-hidden>⚠</span>
+                Generated with warnings
+              </div>
+              <ul className="mt-2 list-disc pl-5 font-mono text-[11px] leading-relaxed text-amber-100/90">
+                {validationWarnings.slice(0, 5).map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           <section className="relative h-[72vh] w-full">
             <div className="relative h-full w-full overflow-hidden rounded-sm border border-rule bg-graphite">
@@ -592,7 +616,9 @@ export default function NewDiagramPage() {
                   <span className="relative h-2 w-2 rounded-full bg-signal" />
                 </span>
                 <span className="font-mono text-[11px] uppercase tracking-[0.22em] text-signal">
-                  Drafting in progress
+                  {streaming.phase === 'retrying'
+                    ? 'Refining output…'
+                    : 'Drafting in progress'}
                 </span>
                 <button
                   type="button"

--- a/src/app/dashboard/diagrams/new/useStreamingGenerate.ts
+++ b/src/app/dashboard/diagrams/new/useStreamingGenerate.ts
@@ -4,10 +4,14 @@ export type StreamingResult = {
   code: string
   title: string
   diagramId: string
+  validationWarnings: string[]
 }
+
+export type StreamingPhase = 'streaming' | 'retrying' | 'idle'
 
 export function useStreamingGenerate() {
   const [isStreaming, setIsStreaming] = useState(false)
+  const [phase, setPhase] = useState<StreamingPhase>('idle')
   const [partialCode, setPartialCode] = useState('')
   const [finalResult, setFinalResult] = useState<StreamingResult | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -30,6 +34,7 @@ export function useStreamingGenerate() {
       abortRef.current = controller
 
       setIsStreaming(true)
+      setPhase('streaming')
       setPartialCode('')
       setFinalResult(null)
       setError(null)
@@ -87,12 +92,21 @@ export function useStreamingGenerate() {
               if (eventType === 'chunk' && parsed.code_delta) {
                 accumulated += parsed.code_delta
                 setPartialCode(accumulated)
+              } else if (eventType === 'retrying') {
+                setPhase('retrying')
+              } else if (eventType === 'replace' && typeof parsed.code === 'string') {
+                accumulated = parsed.code
+                setPartialCode(accumulated)
               } else if (eventType === 'complete' && parsed.done) {
                 setFinalResult({
                   code: parsed.code,
                   title: parsed.title || '',
                   diagramId: parsed.diagram_id || '',
+                  validationWarnings: Array.isArray(parsed.validation_warnings)
+                    ? parsed.validation_warnings
+                    : [],
                 })
+                setPhase('idle')
               } else if (eventType === 'error') {
                 throw new Error(parsed.error || 'Stream error')
               }
@@ -112,6 +126,7 @@ export function useStreamingGenerate() {
       } finally {
         if (!controller.signal.aborted) {
           setIsStreaming(false)
+          setPhase('idle')
         }
       }
     },
@@ -122,6 +137,7 @@ export function useStreamingGenerate() {
     if (abortRef.current) {
       abortRef.current.abort()
       setIsStreaming(false)
+      setPhase('idle')
     }
   }, [])
 
@@ -130,7 +146,8 @@ export function useStreamingGenerate() {
     setPartialCode('')
     setFinalResult(null)
     setError(null)
+    setPhase('idle')
   }, [cancel])
 
-  return { generate, isStreaming, partialCode, finalResult, error, cancel, reset }
+  return { generate, isStreaming, phase, partialCode, finalResult, error, cancel, reset }
 }


### PR DESCRIPTION
## Summary

Consumes the new DiagramAgent SSE contract from flowcraft-api ([PR shagunmistry/flowcraft-api#19](https://github.com/shagunmistry/flowcraft-api/pull/19)):

- `useStreamingGenerate` handles the new \`retrying\` and \`replace\` events; exposes a \`phase\` state (\`'streaming' | 'retrying' | 'idle'\`); surfaces \`validationWarnings: string[]\` on the final result.
- `dashboard/diagrams/new/page.tsx` swaps the streaming header label to "Refining output…" when the agent is retrying; renders an amber warning chip above the diagram when \`validation_warnings\` is non-empty; resets warnings on new-draft.
- Non-streaming diagram + infographic responses also read \`validation_warnings\` from the API — warnings surface regardless of generation mode.

## Dependency

Requires flowcraft-api PR #19 to be deployed first. Until then, no \`retrying\`/\`replace\` events will fire and \`validation_warnings\` will be undefined (handled as empty array).

## Test plan

- [x] \`tsc --noEmit\` clean.
- [ ] Manual smoke: generate a diagram with a deliberately bad prompt; confirm "Refining output…" indicator appears, preview replaces, warnings chip shows if all retries fail.
- [ ] Manual smoke on non-streaming path (infographic): confirm warnings chip renders when API returns warnings.